### PR TITLE
Update criteria.py: handle singular matrix with determinant of a very small number close to 0

### DIFF
--- a/choicedesign/criteria.py
+++ b/choicedesign/criteria.py
@@ -14,7 +14,8 @@ def _derr(design: pd.DataFrame, model: Expression,ndraws):
     _, _, im, _ = model.getValueAndDerivatives(database=Database('design',design),numberOfDraws=ndraws,aggregation=True,prepareIds=True,bhhh=False)
 
     # Calculate D-error
-    if np.linalg.det(im) != 0:
+    # if np.linalg.det(im) != 0:
+    if not np.isclose(np.linalg.det(im), 0):
         vce = np.linalg.solve(im,np.eye(im.shape[0]))
 
         # if asc is not None:


### PR DESCRIPTION
Hi Jose,

I encountered error `LinAlgError("Singular matrix")` that occurred from `criteria.py` (line 18: `vce = np.linalg.solve(im,np.eye(im.shape[0]))`. 

It seems that in this operation, the matrix is singular, but the determinant is not 0 due to floating-point number issue, as mentioned [here](https://stackoverflow.com/questions/13249108/efficient-pythonic-check-for-singular-matrix#:~:text=This%20would%20work,way%20to%20go.). As a result, despite the check `if np.linalg.det(im) != 0:` on line 17, the next line of code is still executed. 

Therefore, I suggest using `np.isclose(<determinant>,0)`.

Note: if relevant, this error occurred in Linux, but not in Windows.